### PR TITLE
Fixing keep aspect ratio issue with the hitbox displayer (#45)

### DIFF
--- a/src/Overlay/Window/HitboxOverlay.h
+++ b/src/Overlay/Window/HitboxOverlay.h
@@ -29,6 +29,7 @@ protected:
 	void AfterDraw() override;
 
 private:
+	void fixAspectRatio(ImVec2& point);
 	void DrawOriginLine(ImVec2 worldPos, float rotationRad);
 	void DrawCollisionAreas(const CharData* charObj, const ImVec2 playerWorldPos);
 
@@ -50,6 +51,12 @@ private:
 	float m_scale = 0.346f;
 	float m_rectThickness = 2.5f;
 	float m_rectFillTransparency = 0.5f;
+
+	// Aspect ratio fixes
+	ImGuiIO io;
+	const float aspectRatio = 5.0f / 3.0f;
+	float displayRatio;
+	const char* aspectRatioAddress;
 
 	ImGuiWindowFlags m_overlayWindowFlags = ImGuiWindowFlags_NoTitleBar
 		| ImGuiWindowFlags_NoInputs


### PR DESCRIPTION
* Fixed the keep aspect ratio issue with the hitbox displayer when in fullscreen/borderless

* made aspect ratio fix a private method and moved some variable initialization to earlier places. Also added the fix to the origin line